### PR TITLE
Fix logarithm typo

### DIFF
--- a/doc/source/Kernels.rst
+++ b/doc/source/Kernels.rst
@@ -9,7 +9,7 @@ You may already seen, we can specify a kernel function like this(same for mean f
 
 There are several points need to be noticed:
 
-1. Most parameters are initilized in their logorithms. This is because we need to make sure they are positive during optimization. e.g. Here length scale and signal variance should always be positive.
+1. Most parameters are initilized in their logarithms. This is because we need to make sure they are positive during optimization. e.g. Here length scale and signal variance should always be positive.
 
 2. Most kernel functions have a scalar in front, namely signal variance(set by log_sigma)
 

--- a/pyGPs/Core/gp.py
+++ b/pyGPs/Core/gp.py
@@ -534,7 +534,7 @@ class GPR(GP):
         '''
         Set noise other than default noise value
 
-        :param log_sigma: logorithm of the noise sigma
+        :param log_sigma: logarithm of the noise sigma
         '''
         self.likfunc = lik.Gauss(log_sigma)
 
@@ -1021,7 +1021,7 @@ class GPR_FITC(GP_FITC):
         '''
         Set noise other than default noise value
 
-        :param log_sigma: logorithm of the noise sigma
+        :param log_sigma: logarithm of the noise sigma
         '''
         self.likfunc = lik.Gauss(log_sigma)
 


### PR DESCRIPTION
logorithm -> logarithm three places in docstrings and docs

Not sure if you want to merge this, but thought I would offer it in any case.